### PR TITLE
fix: override background color for new bsky element

### DIFF
--- a/bsky/firmament.user.css
+++ b/bsky/firmament.user.css
@@ -152,6 +152,8 @@ https://github.com/haraiva/userstyles/tree/main/bsky/safari */
     [style*="border-color"] { border-color: var(--border) !important; }
     
     [fill*="#"] { fill: var(--fg-translucent); }
+
+    .r-13awgt0 { background-color: var(--bg); }
     
     /* but not the 'danger zone' stuff! */
     [style*="color: rgb(235, 36, 82)"] { 

--- a/bsky/safari/firmament.safari.user.css
+++ b/bsky/safari/firmament.safari.user.css
@@ -119,6 +119,8 @@
     [style*="border-color"] { border-color: var(--border) !important; }
     
     [fill*="#"] { fill: var(--fg-translucent); }
+
+    .r-13awgt0 { background-color: var(--bg); }
     
     /* but not the 'danger zone' stuff! */
     [style*="color: rgb(235, 36, 82)"] { 


### PR DESCRIPTION
It looks like there was a new react element added that prevents the themed background from applying everywhere it should. That should be fixed with this PR.

**Before:**
<img width="1214" height="1016" alt="image" src="https://github.com/user-attachments/assets/e0e0b732-eb8a-4a4c-b72a-022871ed1b27" />

**After:**
<img width="1248" height="1012" alt="image" src="https://github.com/user-attachments/assets/ce566106-960b-47da-8299-d67a045a0fb8" />
