### PR TITLE
Fix Clear backgound in alt text modal

### DIFF
--- a/bsky/firmament.user.css
+++ b/bsky/firmament.user.css
@@ -523,6 +523,13 @@ https://github.com/haraiva/userstyles/tree/main/bsky/safari */
         border: 1px solid var(--border) !important; 
         div { color: var(--fg-translucent) !important; }
         }
+
+        /* alt text modal */
+        div[role="dialog"]:has(textarea[placeholder*="ALT"]), 
+        div[role="dialog"]:has(textarea[aria-label*="alt"]),
+        div.css-g5y9jx[role="dialog"] {
+            background-color: var(--option-bg) !important;
+        }
     
     
     /* 🛠️ SETTINGS AND MODERATION UI */
@@ -1122,6 +1129,5 @@ https://github.com/haraiva/userstyles/tree/main/bsky/safari */
              max-width: min(600px, calc(100vw - 24px)) !important;
              border-radius: 8px;
         }
-        
     }
 }


### PR DESCRIPTION
the modal was displaying a transparent BG color making it pretty hard to use

After:
https://github.com/user-attachments/assets/f4417842-5f50-49c4-9624-006d28dc1a8f

Before:
https://github.com/user-attachments/assets/6baa59e5-85bf-45b2-b004-99a81c60ad11

