### PR TITLE
Fix transparent header button fill

### DIFF
--- a/bsky/firmament.user.css
+++ b/bsky/firmament.user.css
@@ -298,7 +298,7 @@ https://github.com/haraiva/userstyles/tree/main/bsky/safari */
         border-radius: 999px;
         background-color: var(--bg) !important;
         div { background-color: transparent !important; }
-        svg path { fill: var(--accent-fg-translucent) !important; }
+        svg path { fill: var(--fg-translucent) !important; }
         &:hover { background-color: var(--bg-darker) !important; }
     }
     


### PR DESCRIPTION
I noticed that paths for the header buttons (namely the back button) were using the `--accent-fg-translucent` variable, which rendered them invisible. Swapping to `--fg-translucent` gets the desired effect.

## Before: 

<img width="210" height="68" alt="firmament_before" src="https://github.com/user-attachments/assets/1743235b-3dbd-4762-8a75-0a66c0c79fb3" />

## After:

<img width="239" height="71" alt="firmament_after" src="https://github.com/user-attachments/assets/9a02e360-eec8-4572-a9da-f2d0adb25825" />
